### PR TITLE
Remove alternate reports due to shutdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,6 @@
             <a href="http://datahackermd.com/2013/language-use-on-github/">Language Use on GitHub</a> visualization of the rank correlation between languages.</li>
             <li><a href="http://www.fastcolabs.com/3015178/the-top-10-hottest-github-projects-right-now?partner=rss">The Top 11 Hottest GitHub Projects Right Now</a></li>
             <li><a href="http://thechangelog.com/nightly/">Subscribe to Changelog Nightly</a> (the new and improved GitHub Archive daily email reports). It ships every night at 10pm CT &mdash; and unearths the hottest new repos on GitHub before they blow up. It's nerd to the core and in your inbox each night.</li>
-            <li>An alternate set of reports: "New repos &amp; most watched" <a href="https://github.com/hnq90/GitHubArchive">email reports</a> (<a href="http://us6.campaign-archive1.com/?u=ecbe15df98da933fc8209cf1b&id=31fc9cb07c">example</a>). Signup: <a href="http://eepurl.com/bb4EFL">daily</a>, <a href="http://eepurl.com/bc5JV9">every 3 days</a>, <a href="http://eepurl.com/bc5Yn9">weekly</a>.</li>
             <li><a href="http://askgithub.com">Ask GitHub</a> - search latest GitHub timeline</li>
             <li><a href="https://github.com/neonichu/githop">GitHop</a> - see your contributions from a year ago.</li>
             <li><a href="http://gitmostwanted.com/">GitMostWanted</a> - Advanced explorer of github.com.</li>


### PR DESCRIPTION
From [the repo's readme](https://github.com/hnq90/GitHubArchive/blob/master/README.md):

> I have to shutdown the server which was running GitHub Archive Newsletter due to overbalance