### PR TITLE
Add GrapHub to the list of projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,6 +183,7 @@
             <li><a href="https://www.gitlive.net/">GitLive</a> - View what's happening on GitHub at real time - Made at Dragon Hacks 2016 Hackathon</li>
             <li><a href="http://archive-observer.herokuapp.com/">ArchiveObserver</a> - Build users open source report cards, refreshed hourly!</li>
             <li><a href="https://public.tableau.com/profile/alysonla#!/vizhome/OpenSourceMonthlyNovember2015/OrgDashboard">Open Source Monthly</a> - An activity dashboard for Open Source Organizations.</li>
+            <li><a href="http://graphub.yodas.com/">GrapHub</a> - Github connections as a D3 graph. Find your GH Erdős number from other GH users by co-contributions.</li>
           </ul>
 
           <p>Have a cool project that should be on this list? <a href="https://github.com/igrigorik/githubarchive.org/tree/gh-pages">Send a pull request</a>!</p>


### PR DESCRIPTION
GrapHub user data from githubarchive in order to construct a co-contributions graph and display it as an attractive D3 interactive graph.

![screen shot 2016-08-02 at 14 30 56](https://cloud.githubusercontent.com/assets/87037/17327003/c89d0cda-58bd-11e6-8c6a-3e42330591ee.png)
